### PR TITLE
Remove the instructions for converting line ends

### DIFF
--- a/Documentation-German.adoc
+++ b/Documentation-German.adoc
@@ -53,11 +53,6 @@ Die aktuellen Hardwareanforderungen und Installationsschritte sind in der https:
 
 Um das spätere Aktualisieren von Klaros-Testmanagement zu erleichtern, wird empfohlen, das Dockerfile von GitHub mit https://git-scm.com[Git] herunterzuladen.
 
-Dadurch das sich der Server während dem Betrieb in einem Linux-Container befindet, und sich die Zeilenendungen von Windows (\r) und Linux (\n) unterscheiden, muss bei der Installation von Git die Option „Checkout as-is, commit Unix-style line endings“ oder „Checkout as-is, commit as-is“ ausgewählt werden.
-
-.Konfiguration für das Konvertieren der Zeilenenden
-image::images/ConfigurationOfTheLineEndConversion.png[Konfiguration für das Konvertieren der Zeilenenden]
-
 Damit sind die Vorbereitungen für Windows abgeschlossen. Im Kapitel <<Installation,Installation>> wird beschrieben, wie das Dockerfile mithilfe von Git Bash heruntergeladen und für zukünftige Updates vorbereitet werden kann.
 ====
 

--- a/Documentation.adoc
+++ b/Documentation.adoc
@@ -53,11 +53,6 @@ The current hardware requirements and installation steps are described in the ht
 
 To make it easier to update Klaros Test Management later, it is recommended to use https://git-scm.com[Git] to download the Dockerfile from GitHub.
 
-Since the server will be running inside a Linux container and the line endings of Windows (\r) and Linux (\n) will be different, the option "Checkout as-is, commit Unix-style line endings" or "Checkout as-is, commit as-is" must be selected when installing Git.
-
-.Configuration for converting the line endings
-image::images/ConfigurationOfTheLineEndConversion.png[Configuration for converting the line endings]
-
 This completes the preparations for Windows. The chapter <<Installation,Installation>> describes how to use Git Bash to download the Dockerfile and prepare it for future updates.
 ====
 

--- a/README-German.adoc
+++ b/README-German.adoc
@@ -55,11 +55,6 @@ Die aktuellen Hardwareanforderungen und Installationsschritte sind in der https:
 
 Um das spätere Aktualisieren von Klaros-Testmanagement zu erleichtern, wird empfohlen, das Dockerfile von GitHub mit https://git-scm.com[Git] herunterzuladen.
 
-Dadurch das sich der Server während dem Betrieb in einem Linux-Container befindet, und sich die Zeilenendungen von Windows (\r) und Linux (\n) unterscheiden, muss bei der Installation von Git die Option „Checkout as-is, commit Unix-style line endings“ oder „Checkout as-is, commit as-is“ ausgewählt werden.
-
-.Konfiguration für das Konvertieren der Zeilenenden
-image::images/ConfigurationOfTheLineEndConversion.png[Konfiguration für das Konvertieren der Zeilenenden]
-
 Damit sind die Vorbereitungen für Windows abgeschlossen. Im Kapitel <<Installation,Installation>> wird beschrieben, wie das Dockerfile mithilfe von Git Bash heruntergeladen und für zukünftige Updates vorbereitet werden kann.
 ====
 

--- a/README.adoc
+++ b/README.adoc
@@ -54,11 +54,6 @@ The current hardware requirements and installation steps are described in the ht
 
 To make it easier to update Klaros Test Management later, it is recommended to use https://git-scm.com[Git] to download the Dockerfile from GitHub.
 
-Since the server will be running inside a Linux container and the line endings of Windows (\r) and Linux (\n) will be different, the option "Checkout as-is, commit Unix-style line endings" or "Checkout as-is, commit as-is" must be selected when installing Git.
-
-.Configuration for converting the line endings
-image::images/ConfigurationOfTheLineEndConversion.png[Configuration for converting the line endings]
-
 This completes the preparations for Windows. The chapter <<Installation,Installation>> describes how to use Git Bash to download the Dockerfile and prepare it for future updates.
 ====
 


### PR DESCRIPTION
With .gitattributes the line ends are automatically converted correctly.