### PR TITLE
Tweak SQL Server catalina-wrapper to allow for remote instances (Replaces #54)

### DIFF
--- a/Microsoft SQL Server/.env
+++ b/Microsoft SQL Server/.env
@@ -3,6 +3,9 @@
 # Set the database host. (note: match service name in docker-compose.yaml)
 DATABASE_HOST=db
 
+# Optional - Only set if your klaros database is not on the default instance
+DATABASE_INSTANCE=
+
 # Set the database username. [DO NOT CHANGE!]
 DATABASE_USER=sa
 

--- a/Microsoft SQL Server/docker-compose.externaldb.yml
+++ b/Microsoft SQL Server/docker-compose.externaldb.yml
@@ -1,0 +1,28 @@
+---
+version: "3.4"
+services:
+    klaros:
+        image: klaros-mssql-ext
+        build:
+            context: ./klaros
+            args:
+                TOMCAT_ADMIN_PASSWORD: ${TOMCAT_PASSWORD}
+        restart: always
+        container_name: ${KLAROS_CONTAINER_NAME}
+        hostname: klaros
+        environment:
+            DATABASE_HOST: ${DATABASE_HOST}
+            DATABASE_INSTANCE: ${DATABASE_INSTANCE}
+            DATABASE_NAME: ${DATABASE_NAME}
+            DATABASE_USER: ${DATABASE_USER}
+            DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+            JAVA_OPTS: -Duser.timezone=${TIMEZONE}
+            TOMCAT_MEMORY_MAX: ${MEMORY_MAX}
+            TOMCAT_MEMORY_MIN: ${MEMORY_MIN}
+        ports:
+            - "${KLAROS_PORT}:18080"
+        volumes:
+            - klaros-data:/data
+volumes:
+    klaros-data:
+        name: ${VOLUME_NAME}

--- a/Microsoft SQL Server/klaros/Dockerfile
+++ b/Microsoft SQL Server/klaros/Dockerfile
@@ -3,10 +3,15 @@
 #
 # Klaros Testmanagement (Community Edition) (https://www.klaros-testmanagement.com)
 #
-# With JAVA_OPTS additional settings can be transferred to the Tomcat server. 
+# With JAVA_OPTS additional settings can be transferred to the Tomcat server.
 # For example the time zone can be set to Europe/Berlin with JAVA_OPTS -Duser.timezone=Europe/Berlin
 #
+# Standalone, docker instance of SQL server:
 # docker-compose up
+#
+# External SQL server connection:
+# Ensure you have created the database by running 002_create_database.sql on your server, then:
+# docker-compose -f docker-compose.externaldb.yml up
 #
 # The .env file contains all possible configuration options. Further information can be found in the documentation.
 #

--- a/Microsoft SQL Server/klaros/files/catalina-wrapper.sh
+++ b/Microsoft SQL Server/klaros/files/catalina-wrapper.sh
@@ -68,9 +68,12 @@ else
 fi
 
 (
-	echo "hibernate.dialect=org.hibernate.dialect.SQLServer2008Dialect"
 	echo "hibernate.connection.driver_class=com.microsoft.sqlserver.jdbc.SQLServerDriver"
-	echo "hibernate.connection.url=jdbc:sqlserver://${DATABASE_HOST}:1433;databaseName=${DATABASE_NAME}"
+	if [ -z "${DATABASE_INSTANCE}" ]; then
+		echo "hibernate.connection.url=jdbc:sqlserver://${DATABASE_HOST}:1433;databaseName=${DATABASE_NAME}"
+	else
+		echo "hibernate.connection.url=jdbc:sqlserver://${DATABASE_HOST};instanceName=${DATABASE_INSTANCE};databaseName=${DATABASE_NAME}"
+	fi
 	echo "hibernate.connection.username=${DATABASE_USER}"
 	echo "hibernate.connection.password=${DATABASE_PASSWORD}"
 ) >/data/klaros-home/hibernate.properties


### PR DESCRIPTION
I needed to make a few tweaks in order to use this docker image with an externally hosted SQL Server instance. 

The biggest thing that had me hitting my head against the wall was getting it to use a named instance (instead of the default, e.g `DBServerHostname\InstanceName` vs just `DBServerHostname`, and it turns out that you can only specify port _or_ instance name, and not both ([reference](https://stackoverflow.com/a/40830281))

I opted to use the `;instanceName=` (with an additional `DATABASE_INSTANCE` env var) in the connection string rather than allowing it to be passed through with `DATABASE_HOST` - as I found that no matter how I formatted/escaped `DBServerHostname\InstanceName` - the `\` would always disappear when the application attempted to connect (showing in the logs as being unable to connect to `DBServerHostnameInstanceName`)

As `DATABASE_INSTANCE` is not needed for the existing `docker-compose.yml`, I have provided an alternative in `docker-compose.externaldb.yml` (invoked as `docker-compose -f docker-compose.externaldb.yml up`)

Anyway, I'm rambling, figured these changes might be of use to someone else in the future